### PR TITLE
change kenig54/node.toml config to accept using ui on remote host

### DIFF
--- a/chains/configs/node.toml
+++ b/chains/configs/node.toml
@@ -14,6 +14,7 @@ processing_threads = 4
 [websockets]
 interface = "0.0.0.0"
 hosts = ["all"]
+origins = ["all"]
 apis = ["web3", "eth", "net", "parity", "traces", "rpc", "personal", "pubsub"]
 
 [footprint]
@@ -26,3 +27,4 @@ reserved_peers = "./bootnodes.txt"
 [ui]
 interface = "127.0.0.1"
 port = 8180
+hosts = ["all"]


### PR DESCRIPTION
these config changes make it possible to using parity user interface on remote host